### PR TITLE
Pypi publish

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -27,7 +27,10 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Run tests
-        run: uv run pytest
+        run: |
+          uv run pytest
+          uv run ruff check src
+          uv run mypy src
 
       - name: Build release distributions
         run: uv build

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -1,0 +1,66 @@
+# This workflow will upload a Python Package to TestPyPI manually
+
+name: Upload Python Package to TestPyPI
+
+on:
+  # Manual trigger
+  # See https://docs.github.com/ja/actions/how-tos/manage-workflow-runs/manually-run-a-workflow
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build release distributions
+        run: uv build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  testpypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/try-or/
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,64 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build release distributions
+        run: uv build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      url: https://pypi.org/project/try-or/
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,10 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Run tests
-        run: uv run pytest
+        run: |
+          uv run pytest
+          uv run ruff check src
+          uv run mypy src
 
       - name: Build release distributions
         run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,27 @@
 [project]
 name = "try-or"
 version = "1.0.0"
-description = "A Python micro-library that returns try value or default. "
+description = "A Python micro-library that returns try value or default."
 readme = "README.md"
+keywords = ["try", "or", "except", "default"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Development Status :: 4 - Beta",
+]
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "nakat-t", email = "armaiti.wizard@gmail.com" }
 ]
 requires-python = ">=3.10"
 dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/nakat-t/try-or-py"
+Repository = "https://github.com/nakat-t/try-or-py"
+Issues = "https://github.com/nakat-t/try-or-py/issues"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "try-or"
-version = "1.0.0"
+version = "1.0.1rc1"
 description = "A Python micro-library that returns try value or default."
 readme = "README.md"
 keywords = ["try", "or", "except", "default"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,10 @@ Issues = "https://github.com/nakat-t/try-or-py/issues"
 [dependency-groups]
 dev = [
     "hypothesis>=6.140.2",
+    "mypy>=1.18.2",
     "pytest>=8.4.2",
     "pytest-cov>=7.0.0",
+    "ruff>=0.13.2",
 ]
 
 [build-system]


### PR DESCRIPTION
This pull request introduces automated workflows for publishing the Python package to both PyPI and TestPyPI, and enhances the package metadata in `pyproject.toml` to improve distribution quality and discoverability. The changes ensure that releases are properly tested, built, and published in a secure and reproducible manner.

**CI/CD: Automated Publishing Workflows**
- Added `.github/workflows/python-publish.yml` to automate publishing to PyPI when a release is published. This workflow builds, tests, and uploads the package securely using trusted publishing.
- Added `.github/workflows/python-publish-testpypi.yml` to enable manual publishing to TestPyPI for pre-release testing, following a similar process as the production workflow.

**Package Metadata Improvements**
- Updated `pyproject.toml`:
  - Bumped version to `1.0.1rc1` for a new release candidate.
  - Added `keywords`, `classifiers`, `license`, and `license-files` to improve package indexing and compliance.
  - Included project URLs for homepage, repository, and issues to enhance PyPI presentation.
  - Added `mypy` and `ruff` to the development dependencies for better code quality checks.