### PR TITLE
Release v1.0.1

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
 
       - name: Install the project
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --all-extras --dev
 
       - name: Run tests
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
 
       - name: Install the project
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --all-extras --dev
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "try-or"
-version = "1.0.1rc1"
+version = "1.0.1"
 description = "A Python micro-library that returns try value or default."
 readme = "README.md"
 keywords = ["try", "or", "except", "default"]


### PR DESCRIPTION
This pull request includes a version bump for the `try-or` package and minor updates to the GitHub workflow files. The most important changes are:

Version update:

* Bumped the package version in `pyproject.toml` from `1.0.1rc1` (release candidate) to the stable release `1.0.1`.

Workflow fix:

* Updated the `uv sync` command in `.github/workflows/python-publish.yml` and `.github/workflows/python-publish-testpypi.yml` to remove the `--locked` flag. [[1]](diffhunk://#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377L26-R26) [[2]](diffhunk://#diff-2aa19aa19bfdeec94c8ebd8083cba7d299a93391f70e1a8df65cb0c14959fc0cL27-R27)